### PR TITLE
Map key script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Ze względów bezpieczeństwa nie udostępniamy ich publicznie w repozytorium, a
 
 ### Automatyczne dodanie klucza
 W Git Bash należy przejść do katalogu ze sklonowanym repozytorium (katalog z folderem `.git`) i wywołać komendę:
-```
-bash set_map_key.sh -k *otrzymany_klucz*
+``` bash
+bash set_map_key.sh -k otrzymany_klucz
 ```
 Należy sprawdzić czy dodano klucz oraz czy Git Bash lub Git Kraken nie wyśledziły zmian w plikach
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ Na gałęzi ```main``` mamy wersję aplikacji, która jest aktualnie na App Stor
 Do odpalenia apki potrzebne są klucze API do Google Maps, bez nich nie wyświetli wam się mapka w aplikacji. 
 Ze względów bezpieczeństwa nie udostępniamy ich publicznie w repozytorium, aby je dostać wystarczy poprosić na Discordzie. Po uzyskaniu klucza należy:
 
+### Automatyczne dodanie klucza
+W Git Bash należy przejść do katalogu ze sklonowanym repozytorium (katalog z folderem `.git`) i wywołać komendę:
+```
+bash set_map_key.sh -k *otrzymany_klucz*
+```
+Należy sprawdzić czy dodano klucz oraz czy Git Bash lub Git Kraken nie wyśledziły zmian w plikach
+```
+/android/app/src/main/AndroidManifest.xml
+/ios/Runner/AppDelegate.swift
+/web/index.html
+```
+
+### Manualne dodanie klucza
 W katalogu repozytorium odpalić te 3 komendy.
 ```
 git update-index --skip-worktree android/app/src/main/AndroidManifest.xml

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Na gałęzi ```main``` mamy wersję aplikacji, która jest aktualnie na App Stor
 
 ## Klucze API
 Do odpalenia apki potrzebne są klucze API do Google Maps, bez nich nie wyświetli wam się mapka w aplikacji. 
-Ze względów bezpieczeństwa nie udostępniamy ich publicznie w repozytorium, aby je dostać wystarczy poprosić na Discordzie. Po uzyskaniu klucza należy:
+Ze względów bezpieczeństwa nie udostępniamy ich publicznie w repozytorium, aby je dostać wystarczy poprosić na Discordzie. Po uzyskaniu klucza są 2 metody dodania go do kodu.
 
 ### Automatyczne dodanie klucza
 W Git Bash należy przejść do katalogu ze sklonowanym repozytorium (katalog z folderem `.git`) i wywołać komendę:
-``` bash
+```
 bash set_map_key.sh -k otrzymany_klucz
 ```
 Należy sprawdzić czy dodano klucz oraz czy Git Bash lub Git Kraken nie wyśledziły zmian w plikach
@@ -17,6 +17,10 @@ Należy sprawdzić czy dodano klucz oraz czy Git Bash lub Git Kraken nie wyśled
 /android/app/src/main/AndroidManifest.xml
 /ios/Runner/AppDelegate.swift
 /web/index.html
+```
+Jeżeli przy wywoływaniu skryptu zostanie wpisany niepoprawny klucz trzeba wywołać po ponowanie z opcjami -k *poprawny klucz* -r *niepoprawny klucz*.
+```
+bash set_map_key.sh -k poprawny_klucz -r niepoprawny_klucz
 ```
 
 ### Manualne dodanie klucza

--- a/set_map_key.sh
+++ b/set_map_key.sh
@@ -6,14 +6,18 @@ if (($# == 0)); then
   echo "Requieres option -k with google map key as argument" >&2
   exit 1
 fi
-while getopts k: opt; do
+key_alias='MAPS_KEY_HERE'
+while getopts k:r: opt; do
   case $opt in
     k)
       map_key=$OPTARG
       ;;
+    r)
+      key_alias=$OPTARG
+      ;;
   esac
 done
-sed -i -e "s/MAPS_KEY_HERE/$map_key/g" android/app/src/main/AndroidManifest.xml
-sed -i -e "s/MAPS_KEY_HERE/$map_key/g" ios/Runner/AppDelegate.swift
-sed -i -e "s/MAPS_KEY_HERE/$map_key/g" web/index.html
+sed -i -e "s/$key_alias/$map_key/g" android/app/src/main/AndroidManifest.xml
+sed -i -e "s/$key_alias/$map_key/g" ios/Runner/AppDelegate.swift
+sed -i -e "s/$key_alias/$map_key/g" web/index.html
 exit 0

--- a/set_map_key.sh
+++ b/set_map_key.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+git update-index --skip-worktree android/app/src/main/AndroidManifest.xml
+git update-index --skip-worktree ios/Runner/AppDelegate.swift
+git update-index --skip-worktree web/index.html
+if (($# == 0)); then
+  echo "Requieres option -k with google map key as argument" >&2
+  exit 1
+fi
+while getopts k: opt; do
+  case $opt in
+    k)
+      map_key=$OPTARG
+      ;;
+  esac
+done
+sed -i -e "s/MAPS_KEY_HERE/$map_key/g" android/app/src/main/AndroidManifest.xml
+sed -i -e "s/MAPS_KEY_HERE/$map_key/g" ios/Runner/AppDelegate.swift
+sed -i -e "s/MAPS_KEY_HERE/$map_key/g" web/index.html
+exit 0

--- a/set_map_key.sh
+++ b/set_map_key.sh
@@ -2,10 +2,6 @@
 git update-index --skip-worktree android/app/src/main/AndroidManifest.xml
 git update-index --skip-worktree ios/Runner/AppDelegate.swift
 git update-index --skip-worktree web/index.html
-if (($# == 0)); then
-  echo "Requieres option -k with google map key as argument" >&2
-  exit 1
-fi
 key_alias='MAPS_KEY_HERE'
 while getopts k:r: opt; do
   case $opt in
@@ -17,6 +13,10 @@ while getopts k:r: opt; do
       ;;
   esac
 done
+if [ -z "$map_key" ]; then
+  echo 'Missing required Google Map key' >&2
+  exit 1
+fi
 sed -i -e "s/$key_alias/$map_key/g" android/app/src/main/AndroidManifest.xml
 sed -i -e "s/$key_alias/$map_key/g" ios/Runner/AppDelegate.swift
 sed -i -e "s/$key_alias/$map_key/g" web/index.html


### PR DESCRIPTION
Dodano skrypt w bashu. Skrypt służy do dodawania klucza Google Map i untrackowania plików zawierających klucz.
Uaktualniono README - zawiera informację jak odpalić skrypt.